### PR TITLE
extern "C"

### DIFF
--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -6,6 +6,7 @@ tab_width = 2
 language = "C"
 style = "Both"
 documentation_style = "Doxy"
+cpp_compat = true
 
 [fn]
 args = "Vertical"


### PR DESCRIPTION
https://github.com/eqrion/cbindgen/blob/master/docs.md#cbindgentoml
```
# Whether to make a C header C++ compatible.
# These will wrap generated functions into a `extern "C"` block, e.g.
#
# #ifdef __cplusplus
# extern "C" {
# #endif // __cplusplus
#
# // Generated functions.
#
# #ifdef __cplusplus
# } // extern "C"
# #endif // __cplusplus
#
# If the language is not C this option won't have any effect.
#
# default: false
cpp_compat = false
```